### PR TITLE
Fix scriptblock being serialised as empty string

### DIFF
--- a/Source/Public/ConvertTo-Metadata.ps1
+++ b/Source/Public/ConvertTo-Metadata.ps1
@@ -108,7 +108,7 @@ function ConvertTo-Metadata {
             "@($($(ForEach($item in @($InputObject)) { $item | ConvertTo-Metadata -AsHashtable:$AsHashtable}) -join ","))"
         } elseif($InputObject -is [System.Management.Automation.ScriptBlock]) {
             # Escape single-quotes by doubling them:
-            "(ScriptBlock '{0}')" -f ("$_" -replace "'", "''")
+            "(ScriptBlock '{0}')" -f ($InputObject -replace "'", "''")
         } elseif ($InputObject.GetType().FullName -eq 'System.Management.Automation.PSCustomObject') {
             # NOTE: we can't put [ordered] here because we need support for PS v2, but it's ok, because we put it in at parse-time
             $(if ($AsHashtable) {


### PR DESCRIPTION
Hi, spotted this bug.

Repro:
```
{foo} | Export-Metadata .\test.psd1; gc .\test.psd1
# output: (ScriptBlock '')
```

With fix:
```
{foo} | Export-Metadata .\test.psd1; gc .\test.psd1
# output: (ScriptBlock 'foo')
```

It seems that I can't work around this by passing a converter, unfortunately.